### PR TITLE
Update target subdomain selection

### DIFF
--- a/cors_service/tests/web/logic/test_targets.py
+++ b/cors_service/tests/web/logic/test_targets.py
@@ -475,7 +475,7 @@ class TestTargetManager:
     @patch("web.logic.amass.AmassManager.enumerate_subdomains_for_domain")
     @patch("web.logic.targets.TargetManager.test_domains_for_https")
     def test_scan_parent_domain_many_results_all_https_mixed_codes(
-            self, test_domains_for_https, enumerate_subdomains_for_domain
+        self, test_domains_for_https, enumerate_subdomains_for_domain
     ) -> None:
         """Tests scan_parent_domain to ensure that it creates all of the expected database records when
         many results are found from a subdomain scan, all respond to HTTPS, and some of those responses

--- a/cors_service/web/logic/targets.py
+++ b/cors_service/web/logic/targets.py
@@ -204,7 +204,9 @@ class TargetManager:
             f"Now testing to see which of those domains may be an internal-facing domain..."
         )
         live_subdomains = TargetManager.test_domains_for_https(domains=subdomains)
-        live_subdomains_200s = [x[0] for x in filter(lambda x: x[1] == 200, live_subdomains)]
+        live_subdomains_200s = [
+            x[0] for x in filter(lambda x: x[1] == 200, live_subdomains)
+        ]
         internal_domains = set(subdomains) - set(live_subdomains_200s)
         if len(internal_domains) == 0:
             logger.warning(


### PR DESCRIPTION
## Description of Change

This PR updates our "internal domain" selection logic to follow the rule of "a subdomain is _not_ a target if it (1) responds to HTTPS AND (2) the HTTP status code of that response is a 200.

## Impact of Change

Less strict rules around subdomain selection.

## Collateral Work

Rest of Terraform.

## Testing

Unit tests updated and added as necessary.