### PR TITLE
Make: Add target to configure locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,11 @@ configure_heroku :
 	$(eval YAML_CONTENT := $(shell cat $(CONFIG_FILE) | base64 | tr -d '\r\n'))
 	heroku run -a $(HEROKU_APP_NAME) "python manage.py configure_from_yaml -s $(YAML_CONTENT)"
 
+configure_local:
+	echo "Configuring Local deployment based on contents of '$(CONFIG_FILE)' configuration file..."
+	$(eval YAML_CONTENT := $(shell cat $(CONFIG_FILE) | base64 | tr -d '\r\n'))
+	python manage.py configure_from_yaml -s $(YAML_CONTENT)
+
 open_heroku_console :
 	echo "Opening a browser to the results viewing page for the remote deployment on Heroku (config file at '$(CONFIG_FILE)')..."
 	$(eval HEROKU_APP_NAME := $(shell python manage.py get_terraform_arg -f $(CONFIG_FILE) -a heroku_app_name))


### PR DESCRIPTION
I think it's useful to have a make target that configures the local db like the db in heroku is configured.